### PR TITLE
Add npm and node commands which is platform independent.

### DIFF
--- a/bootstrap/absolute.sh
+++ b/bootstrap/absolute.sh
@@ -12,7 +12,6 @@ sync_node
 sync_mongodb
 
 # Set path
-set_path_env $(third_party_path)/node/bin
 set_path_env $(third_party_path)/mongodb/bin
 set_path_env $(bootstrap_command_path)
 set_path_env $(server_path)/node_modules/.bin

--- a/bootstrap/command/node
+++ b/bootstrap/command/node
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# Copyright (c) 2017 The Absolute Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+. bootstrap/common/path_info.sh
+. bootstrap/common/platform_info.sh
+
+if is_windows_platform; then
+  $(third_party_path)/node/node.cmd $@
+else
+  $(third_party_path)/node/bin/node $@
+fi

--- a/bootstrap/command/npm
+++ b/bootstrap/command/npm
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# Copyright (c) 2017 The Absolute Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+. bootstrap/common/path_info.sh
+. bootstrap/common/platform_info.sh
+
+if is_windows_platform; then
+  $(third_party_path)/node/npm.cmd $@
+else
+  $(third_party_path)/node/bin/npm $@
+fi


### PR DESCRIPTION
We are using win-bash but the shell can not recognize and execute *.cmd files.
So, add some commands to bootstrap to execute and use the same commands in each
other platforms.