### PR TITLE
Fix a bug when syncing node js binary on windows.

### DIFF
--- a/bootstrap/common/sync_third_party.sh
+++ b/bootstrap/common/sync_third_party.sh
@@ -47,7 +47,7 @@ function sync_third_party() {
   fi
 
   if is_windows_platform; then
-    local temp_path=$TMP/tmp_$RANDOM
+    local temp_path=C:/tmp_$RANDOM
     mkdir -p $temp_path
   else
     local temp_path=$(mktemp -d)


### PR DESCRIPTION
When syncing node js binary on windows, especially, when extracting zip file
after downloading, too long path errors occurs. Currently, we are using $TMP
directory(in general the directory path is C:\Users\{NAME}\AppData\Local\Temp),
but it's too long basically. So, this CL is changing it to shorten path instead.