### PR TITLE
Fix a bug when running absolute.cmd in Windows

### DIFF
--- a/absolute.cmd
+++ b/absolute.cmd
@@ -3,5 +3,5 @@
 :: found in the LICENSE file.
 
 @ECHO OFF
-set %ABSOLUTE_PATH%=%~dp0
-cd %~dp0 && third_party\win-bash\bash bootstrap\absolute.sh %*
+set ABSOLUTE_PATH=%~dp0
+cd %ABSOLUTE_PATH% && third_party\win-bash\bash bootstrap\absolute.sh %*

--- a/bootstrap/absolute.sh
+++ b/bootstrap/absolute.sh
@@ -4,8 +4,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-. bootstrap/common/path_info.sh
-. bootstrap/common/sync_third_party.sh
+. $ABSOLUTE_PATH/bootstrap/common/path_info.sh
+. $ABSOLUTE_PATH/bootstrap/common/sync_third_party.sh
 
 # Sync third_parties.
 sync_node


### PR DESCRIPTION
There was a problem when running absolute.cmd in Windows because of script path setting.
So I discussed it with romandev then modified scripts to fix this issue.