### PR TITLE
Bug fix - type command does not work in window. (#77)

### DIFF
--- a/bootstrap/common/sync_third_party.sh
+++ b/bootstrap/common/sync_third_party.sh
@@ -57,6 +57,11 @@ function sync_third_party() {
   # The trap will work well when unknown breaking happens like ctrl+c.
   trap "rm -rf $temp_path" EXIT
 
+  # for type command in can_use_command function.
+  if is_windows_platform; then
+    set_path_env $(third_party_path)/win-bash
+  fi
+
   # Download the file of url into temporary path.
   if ! download $url $temp_path; then
     return 2

--- a/bootstrap/common/util.sh
+++ b/bootstrap/common/util.sh
@@ -28,7 +28,7 @@ function download() {
   fi
 
   echo "Downloading... $url"
-  if is_windows_platform || can_use_command wget; then
+  if is_windows_platform && can_use_command wget; then
     mkdir -p $path && wget $url -P $path > /dev/null 2>&1
   else
     mkdir -p $path && cd $path && \


### PR DESCRIPTION
1. The "type" command does not work when call it from "third_party/win-bash/bash" in window OS. Because "third_party/win-bash" path not in PATH env. So "type" can't find argument command always except builtin command.
2. "if" condition fix in download function to use wget when only can use wget command.

After this path "absolute start" command work in window git bash.