### PR TITLE
Deeplink should be sent when users are using andorid phone.

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -8,7 +8,8 @@
 </head>
 <body>
   <script>
-    deeplink.createBrowser('com.android.chrome');
+    if(navigator.userAgent.indexOf("Android")>-1)
+      deeplink.createBrowser('com.android.chrome');
   </script>
 Absolute Client!
 </body>


### PR DESCRIPTION
Deeplink should be sent when user are using andorid phone.
We blocked sending deeplink when users are using the others phones.

BUG=#96