### PR TITLE
add help implementation by using gulp-help-doc

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -9,6 +9,7 @@ import gulp from 'gulp';
 import nodemon from 'gulp-nodemon';
 import runSequence from 'run-sequence';
 import sourcemaps from 'gulp-sourcemaps';
+import usage from 'gulp-help-doc'
 
 process.on('exit', () => {
   runSequence('stop');
@@ -30,9 +31,13 @@ process.on('disconnect', () => {
 gulp.task('default', ['help']);
 
 gulp.task('help', () => {
-  // TODO(zino): We should implement this command.
+  return usage(gulp);
 });
 
+/**
+ * build absolute
+ * @task {build}
+ */
 gulp.task('build', () => {
   return gulp.src(['./server/**/*.js'])
     .pipe(sourcemaps.init())
@@ -41,6 +46,10 @@ gulp.task('build', () => {
     .pipe(gulp.dest('out'))
 });
 
+/**
+ * run lint
+ * @task {lint}
+ */
 gulp.task('lint', finish => {
   return gulp.src(['./server/**/*.js'])
     .pipe(eslint())
@@ -48,10 +57,18 @@ gulp.task('lint', finish => {
     .pipe(eslint.failAfterError())
 });
 
+/**
+ * start absolute
+ * @task {start}
+ */
 gulp.task('start', () => {
   runSequence('start_db', 'lint', 'build', 'start_server');
 });
 
+/**
+ * start server
+ * @task {start_server}
+ */
 gulp.task('start_server', () => {
   nodemon({
     script: 'server.js',
@@ -59,6 +76,10 @@ gulp.task('start_server', () => {
   });
 });
 
+/**
+ * start db
+ * @task {start_db}
+ */
 gulp.task('start_db', finish => {
   child_process.exec('mongod --fork --dbpath database --logpath database/log', error => {
     if (error)
@@ -69,6 +90,10 @@ gulp.task('start_db', finish => {
   });
 });
 
+/**
+ * stop server
+ * @task {stop}
+ */
 // FIXME(zino): This command is not working well in some cases. (e.g. CTRL + C)
 gulp.task('stop', finish => {
   child_process.exec('mongo admin --eval "db.shutdownServer();"', error => {
@@ -77,3 +102,4 @@ gulp.task('stop', finish => {
     }, 1000);
   });
 });
+

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
     "gulp-eslint": "^3.0.1",
+    "gulp-help-doc": "^1.1.0",
     "gulp-load-plugins": "^1.2.4",
     "gulp-nodemon": "^2.2.1",
     "gulp-sourcemaps": "^1.6.0",


### PR DESCRIPTION
add help implementation using by gulp-help-doc

Usage: gulp [task] [options]
Tasks: