### PR TITLE
Enable eslint rule es6/no-var-requires

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "babel-preset-es2015": "^6.0.15",
     "babel-preset-es2017": "^6.0.15",
     "eslint-config-google": "^0.7.1",
+    "eslint-plugin-es6": "^1.0.0",
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
     "gulp-eslint": "^3.0.1",
@@ -35,12 +36,14 @@
       "node": true
     },
     "extends": ["eslint:recommended", "google"],
+    "plugins": ["es6"],
     "parserOptions": {
       "ecmaVersion": 2017,
       "sourceType": "module"
     },
     "rules": {
-      "no-console": 0
+      "no-console": 0,
+      "es6/no-var-requires": 2
     }
   }
 }


### PR DESCRIPTION
Issue #237 is raised and to solve this issue, I created eslint-plugin-es6
repository then wrote eslint rule for forcing to use import instead of
require.