### PR TITLE
Add bootstrap_test to travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,4 @@ os:
 language: node_js
 script:
   - ./absolute lint
+  - ./absolute bootstrap_test


### PR DESCRIPTION
We introduced a new bootstrap test instead of legacy platform_test in #242. But
the test is still disabled in travis. So, enables the test in travis for test
automation to ensure that it works well in all platforms.