### PR TITLE
Add support for CMD test on Windows.

### DIFF
--- a/absolute.cmd
+++ b/absolute.cmd
@@ -4,4 +4,5 @@
 
 @ECHO OFF
 set ABSOLUTE_PATH=%~dp0
+Get-Process
 cd %ABSOLUTE_PATH% && third_party\win-bash\bash bootstrap\absolute.sh %*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,6 @@ environment:
   nodejs_version: "6"
 
 test_script:
-  - ./absolute lint
-  - ./absolute bootstrap_test
+  - ps: ./absolute lint
 
 build: off


### PR DESCRIPTION
Introduced Windows test bot in #278 but it does test on PowerShell only.
But some developer might use a legacy CMD instead of PowserShell. So, we should
support for CMD test on Windows.

ISSUE=#139