### PR TITLE
Only allows |branch| update test bots on master branch.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,8 +1,9 @@
-environment:
-  nodejs_version: "6"
+build: off
+
+branches:
+  only:
+    - master
 
 test_script:
   - ./absolute lint
   - ./absolute bootstrap_test
-
-build: off

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 os:
   - linux
   - osx
+
 language: node_js
+
+branches:
+  only:
+    - master
+
 script:
   - ./absolute lint
   - ./absolute bootstrap_test


### PR DESCRIPTION
The |branch| update test bots are triggered when target branch is updated.
(including temporary branch to send a pull request) But it can be overkill
because there are already |pull request| update test bots. We don't need to
have duplicated test bots the same pull request. So, add white-lists to block
other branches except master branch.