### PR TITLE
Apply sourcemap to server (about Issue #300)

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -41,7 +41,7 @@ gulp.task('build_server', () => {
     .pipe(sourcemaps.init())
     .pipe(babel())
     .on('error', error => {console.log(error);})
-    .pipe(sourcemaps.write())
+    .pipe(sourcemaps.write('.', {sourceRoot: path.resolve(__dirname, 'server')}))
     .pipe(gulp.dest(path.resolve(__dirname, 'out', 'server')))
 });
 

--- a/package.json
+++ b/package.json
@@ -26,8 +26,9 @@
     "run-sequence": "^1.0.1",
     "sass-loader": "^6.0.5",
     "style-loader": "^0.18.2",
-    "url-loader": "^0.5.8",
-    "webpack": "^2.6.1"
+    "source-map-support": "^0.4.15",
+    "webpack": "^2.6.1",
+    "url-loader": "^0.5.8"
   },
   "dependencies": {
     "express": "~4.15.2",

--- a/server/config.js
+++ b/server/config.js
@@ -2,6 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import sourceMapSupport from 'source-map-support';
+
+// It provides source map support for stack traces in node
+sourceMapSupport.install({environment: 'node'});
+
 export default {
   httpPort: 9080,
   httpsPort: 9443,

--- a/server/database.js
+++ b/server/database.js
@@ -2,6 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import sourceMapSupport from 'source-map-support';
+
+// It provides source map support for stack traces in node
+sourceMapSupport.install({environment: 'node'});
+
 /**
  * Print log.
  * @param {number} data to be printed out

--- a/server/https_server/https_server.js
+++ b/server/https_server/https_server.js
@@ -4,6 +4,10 @@
 
 import fs from 'fs';
 import https from 'https';
+import sourceMapSupport from 'source-map-support';
+
+// It provides source map support for stack traces in node
+sourceMapSupport.install({environment: 'node'});
 
 /**
  * Run https server

--- a/server/https_server/redirect_server.js
+++ b/server/https_server/redirect_server.js
@@ -4,6 +4,10 @@
 
 import express from 'express';
 import http from 'http';
+import sourceMapSupport from 'source-map-support';
+
+// It provides source map support for stack traces in node
+sourceMapSupport.install({environment: 'node'});
 
 /**
  * Redirect http to https

--- a/server/push/controllers/send_push.js
+++ b/server/push/controllers/send_push.js
@@ -3,9 +3,12 @@
 // found in the LICENSE file.
 
 import config from '../../config';
+import sourceMapSupport from 'source-map-support';
 import webpush from 'web-push';
 import * as pushKeys from '../gen_push_key';
 
+// It provides source map support for stack traces in node
+sourceMapSupport.install({environment: 'node'});
 
 /**
  * Send push with payload to endpoint with it's authentication key.

--- a/server/server.js
+++ b/server/server.js
@@ -7,10 +7,14 @@ import config from './config';
 import express from 'express';
 import mongoose from 'mongoose';
 import path from 'path';
+import sourceMapSupport from 'source-map-support';
 
 import * as httpsServer from './https_server/https_server';
 import * as pushKeys from './push/gen_push_key';
 import * as redirectServer from './https_server/redirect_server';
+
+// It provides source map support for stack traces in node
+sourceMapSupport.install({environment: 'node'});
 
 const app = express();
 

--- a/server/worker_manager.js
+++ b/server/worker_manager.js
@@ -4,6 +4,10 @@
 
 import cluster from 'cluster';
 import os from 'os';
+import sourceMapSupport from 'source-map-support';
+
+// It provides source map support for stack traces in node
+sourceMapSupport.install({environment: 'node'});
 
 // Policy of dispatching task to another worker available
 // cluster.SCHED_NONE to leave it to the operating system


### PR DESCRIPTION
This patch provides source map support for stack traces in node.

It uses the source-map module to replace the paths and line numbers of source-mapped files with their original paths and line numbers. The output mimics node's stack trace format with the goal of making every compile-to-JS language more of a first-class citizen. Source maps are completely general (not specific to any one language) so you can use source maps with multiple compile-to-JS languages in the same node process.
