### PR TITLE
Add sort-imports rule.

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,10 @@
       "sourceType": "module"
     },
     "rules": {
-      "no-console": 0
+      "no-console": 0,
+      "sort-imports": ["error", {
+        "memberSyntaxSortOrder": ["single", "multiple", "all", "none"]
+      }]
     }
   }
 }

--- a/server/server.js
+++ b/server/server.js
@@ -2,14 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import express from 'express';
-import path from 'path';
 import bodyParser from 'body-parser';
-
 import config from './config';
+import express from 'express';
 import httpsServer from './https_server/https_server';
-import redirectServer from './https_server/redirect_server';
 import mongoose from 'mongoose';
+import path from 'path';
+import redirectServer from './https_server/redirect_server';
 
 const app = express();
 


### PR DESCRIPTION
When declaring multiple imports, a sorted list of import declarations make it
easier for developers to read the code and find necessary imports later.