### PR TITLE
Add |indent| rule to our lint.

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     },
     "rules": {
       "no-console": 0,
+      "indent": ["error", 2],
       "sort-imports": ["error", {
         "memberSyntaxSortOrder": ["single", "multiple", "all", "none"]
       }]

--- a/server/worker_manager.js
+++ b/server/worker_manager.js
@@ -17,9 +17,9 @@ if (cluster.isMaster) {
   });
   // recieve message from worker
   cluster.on('exit', (worker, code, siganl) => {
-      if (code == 200) {
-          // cluster.fork();
-      }
+    if (code == 200) {
+      // cluster.fork();
+    }
   });
 } else if (cluster.isWoker) {
   // child worker


### PR DESCRIPTION
We are using 2-space indentation but there is no rule in our lint configuration.

Related link:
  http://eslint.org/docs/rules/indent