### PR TITLE
Add |no-commonjs| rule by introducing eslint-plugin-import.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "babel-preset-es2015": "^6.0.15",
     "babel-preset-es2017": "^6.0.15",
     "eslint-config-google": "^0.7.1",
+    "eslint-plugin-import": "^2.3.0",
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
     "gulp-eslint": "^3.0.1",
@@ -39,7 +40,9 @@
     },
     "extends": [
       "eslint:recommended",
-      "google"
+      "google",
+      "plugin:import/errors",
+      "plugin:import/warnings"
     ],
     "parserOptions": {
       "ecmaVersion": 2017,
@@ -47,6 +50,7 @@
     },
     "rules": {
       "no-console": 0,
+      "import/no-commonjs": [2, "allow-primitive-modules"],
       "indent": ["error", 2],
       "sort-imports": ["error", {
         "memberSyntaxSortOrder": ["single", "multiple", "all", "none"]

--- a/server/config.js
+++ b/server/config.js
@@ -2,9 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-const config = module.exports;
-
-config.serverInfo = {
+export default {
   httpPort: 9080,
   httpsPort: 9443,
   dbPort: 27017,

--- a/server/https_server/https_server.js
+++ b/server/https_server/https_server.js
@@ -10,7 +10,7 @@ import https from 'https';
  * @param {object} app
  * @param {object} serverInfo
  */
-function run(app, serverInfo) {
+export function run(app, serverInfo) {
   const certificationInfo = {
     key: fs.readFileSync(serverInfo.certification.key),
     cert: fs.readFileSync(serverInfo.certification.cert),
@@ -19,5 +19,3 @@ function run(app, serverInfo) {
   const httpsServer = https.createServer(certificationInfo, app);
   httpsServer.listen(serverInfo.httpsPort);
 }
-
-exports.run = run;

--- a/server/https_server/redirect_server.js
+++ b/server/https_server/redirect_server.js
@@ -9,7 +9,7 @@ import http from 'http';
  * Redirect http to https
  * @param {object} serverInfo
  */
-function runForHttps(serverInfo) {
+export function runForHttps(serverInfo) {
   const redirectApp = express();
   const redirectServer = http.createServer(redirectApp);
 
@@ -24,5 +24,3 @@ function runForHttps(serverInfo) {
   });
   redirectServer.listen(serverInfo.httpPort);
 }
-
-exports.runForHttps = runForHttps;

--- a/server/server.js
+++ b/server/server.js
@@ -5,10 +5,11 @@
 import bodyParser from 'body-parser';
 import config from './config';
 import express from 'express';
-import httpsServer from './https_server/https_server';
 import mongoose from 'mongoose';
 import path from 'path';
-import redirectServer from './https_server/redirect_server';
+
+import * as httpsServer from './https_server/https_server';
+import * as redirectServer from './https_server/redirect_server';
 
 const app = express();
 
@@ -20,5 +21,5 @@ app.use(bodyParser.urlencoded({
 }));
 
 mongoose.connect(`${config.ip}:${config.dbPort}/absolute`);
-httpsServer.run(app, config.serverInfo);
-redirectServer.runForHttps(config.serverInfo);
+httpsServer.run(app, config);
+redirectServer.runForHttps(config);


### PR DESCRIPTION
We wanted to stop using commonjs style such as require() but there is no lint
rule to force it. To resolve the issue, we add |no-commonjs| rule by introducing
eslint-plugin-import[1].

[1] https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-commonjs.md