### PR TITLE
Fix a regression after #283.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "express": "~4.15.2",
     "body-parser": "~1.16.1",
+    "mongoose": "^4.10.5",
     "web-push": "~3.2.2"
   },
   "engines": {


### PR DESCRIPTION
There was no declaration for |mongoose| in the dependencies entry in
package.json.

It can cause like the following error:
  Error: Cannot find module 'mongoose'
    at Function.Module._resolveFilename (module.js:469:15)
    at Function.Module._load (module.js:417:25)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (absolute/out/server/server.js:15:17)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)