### PR TITLE
Override install section in .travis.yml for disabling default |npm install|.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ branches:
   only:
     - master
 
+install:
+  # Override this section for disabling default |npm install|.
+  - ./absolute
+
 script:
   - ./absolute lint
   - ./absolute bootstrap_test


### PR DESCRIPTION
This is fixing travis bot error after #308 change.