### PR TITLE
Introduce access modifier decorator.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,19 +1,21 @@
 {
   "babel": {
     "presets": [
-      "es2015",
+      "babel-preset-es2015-without-strict",
       "es2017"
     ],
     "plugins": [
-      "transform-decorators-legacy"
+      "transform-decorators-legacy",
+      "transform-class-properties"
     ]
   },
   "devDependencies": {
     "babel-core": "^6.14.0",
     "babel-eslint": "^7.2.3",
     "babel-loader": "^7.0.0",
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
-    "babel-preset-es2015": "^6.0.15",
+    "babel-preset-es2015-without-strict": "0.0.4",
     "babel-preset-es2017": "^6.0.15",
     "css-loader": "^0.28.4",
     "eslint-config-google": "^0.7.1",
@@ -28,12 +30,13 @@
     "gulp-sourcemaps": "^1.6.0",
     "mocha": "^3.4.1",
     "node-sass": "^4.5.3",
+    "private-decorator": "^0.1.7",
     "run-sequence": "^1.0.1",
     "sass-loader": "^6.0.5",
-    "style-loader": "^0.18.2",
     "source-map-support": "^0.4.15",
-    "webpack": "^2.6.1",
-    "url-loader": "^0.5.8"
+    "style-loader": "^0.18.2",
+    "url-loader": "^0.5.8",
+    "webpack": "^2.6.1"
   },
   "dependencies": {
     "express": "~4.15.2",
@@ -66,11 +69,25 @@
     },
     "rules": {
       "no-console": 0,
-      "import/no-commonjs": [2, "allow-primitive-modules"],
-      "indent": ["error", 2],
-      "sort-imports": ["error", {
-        "memberSyntaxSortOrder": ["single", "multiple", "all", "none"]
-      }]
+      "import/no-commonjs": [
+        2,
+        "allow-primitive-modules"
+      ],
+      "indent": [
+        "error",
+        2
+      ],
+      "sort-imports": [
+        "error",
+        {
+          "memberSyntaxSortOrder": [
+            "single",
+            "multiple",
+            "all",
+            "none"
+          ]
+        }
+      ]
     }
   }
 }

--- a/server/base/access_modifier.js
+++ b/server/base/access_modifier.js
@@ -1,0 +1,30 @@
+// Copyright (c) 2017 The Absolute Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// TODO(zino): The private-decorator doesn't support import-style module load.
+// So, to avoid lint error, we disable eslint the following line for now.
+/* eslint-disable */
+import {privateMember, protectedMember} from 'private-decorator';
+/* eslint-enable */
+
+/**
+ * TODO(zino): This class is providing access modifiers such as |private|,
+ * |protected|. Currently, we are just using private-decorator module internally
+ * but there are some problems. So, we should replace this wrapper with our own
+ * implementation.
+ */
+export default class access {
+  static private = privateMember;
+  static protected = protectedMember;
+}

--- a/server/example/example.js
+++ b/server/example/example.js
@@ -1,0 +1,50 @@
+// Copyright (c) 2017 The Absolute Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import access from '../base/access_modifier.js';
+
+/**
+ * ExampleBase class
+ */
+class ExampleBase {
+  @access.private privateProperty = 'privateProperty';
+  @access.protected protectedProperty = 'protectedProperty';
+}
+
+/**
+ * Example class
+ */
+export default class Example extends ExampleBase {
+  // Private properties
+  @access.private privateProperty1 = 10;
+  @access.private privateProperty2 = 'privateProperty2';
+
+  @access.private
+  /**
+   * TODO(zino): Currently, we can not put this jsdoc comment above access
+   * modifier decorator.
+   *
+   * This is privateMethod().
+   */
+  privateMethod() {
+    console.log('This is privateMethod().');
+  }
+
+  /**
+   * This is publicMethod().
+   */
+  publicMethod() {
+    console.log('This is publicMethod().');
+  }
+}


### PR DESCRIPTION
Currently, latest ECMA standard can not support access modifiers such as
private, public and protected. However, sometimes they are useful for
perspective of readability. So, this change is providing decorators that can be
used similar to access modifiers. Please see example.js attached to this patch.