### PR TITLE
Generate vapid keys on absolute start in gulp

### DIFF
--- a/client/push/push_key.js
+++ b/client/push/push_key.js
@@ -1,0 +1,5 @@
+export default {
+  'pushVapidKeys': {
+    'publicKey': ''
+  }
+}

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -19,6 +19,7 @@ import gulp from 'gulp';
 import mocha from 'gulp-mocha';
 import nodemon from 'gulp-nodemon';
 import path from 'path';
+import generatePushKey from './server/push/gen_push_key'
 import runSequence from 'run-sequence';
 import sourcemaps from 'gulp-sourcemaps';
 import webpack from 'webpack';
@@ -60,7 +61,8 @@ gulp.task('lint', finish => {
 });
 
 gulp.task('lint_server', finish => {
-  return gulp.src(['./server/**/*.js', '!./server/**/*.router.js'])
+  return gulp.src(['./server/**/*.js', '!./server/**/*.router.js',
+    '!./server/push/push_key.js'])
     .pipe(eslint())
     .pipe(eslint.format())
     .pipe(eslint.failAfterError());
@@ -82,8 +84,12 @@ gulp.task('lint_router', finish => {
     .pipe(eslint.failAfterError());
 });
 
+gulp.task('push_key', () => {
+  generatePushKey();
+});
+
 gulp.task('start', () => {
-  runSequence('start_db', 'lint', 'build_server', 'build_client', 'start_server');
+  runSequence('start_db', 'lint', 'push_key', 'build_server', 'build_client', 'start_server');
 });
 
 gulp.task('start_server', () => {

--- a/server/push/controllers/send_push.js
+++ b/server/push/controllers/send_push.js
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 import config from '../../config';
+import pushKeys from '../push_key';
 import sourceMapSupport from 'source-map-support';
 import webpush from 'web-push';
-import * as pushKeys from '../gen_push_key';
 
 // It provides source map support for stack traces in node
 sourceMapSupport.install({environment: 'node'});
@@ -31,10 +31,11 @@ export function sendPush(endpoint, keys, payload) {
   const SERVER_SUBJECT = 'https://github.com/romandev/absolute';
   return new Promise((resolve, reject) => {
     webpush.setGCMAPIKey(config.serverInfo.pushServerKey);
+    webpush.setGCMAPIKey(pushKeys.pushServerKey);
     webpush.setVapidDetails(
       SERVER_SUBJECT,
-      pushKeys.getPushKey().pushVapidKeys.publicKey,
-      pushKeys.getPushKey().pushVapidKeys.privateKey,
+      pushKeys.pushVapidKeys.publicKey,
+      pushKeys.pushVapidKeys.privateKey,
     );
 
     // This is the same output of calling JSON.stringify on a PushSubscription

--- a/server/push/push_key.js
+++ b/server/push/push_key.js
@@ -1,0 +1,7 @@
+export default {
+  'pushServerKey': 'AAAAuU4aFAY:APA91bHL6gDxgTYMHD7q2hTKD_6GwYOcDhPTjiM14vYWwRwAmkl3rijIRnK-9-NdFvy8hrcXvi8IvBLhEPOUQZxZ2N00roSkH1U3tLX7sOGxzsKkTXHp9R2i-GbmYVkK9yYz0RF_wZfP',
+  'pushVapidKeys': {
+    'publicKey': '',
+    'privateKey': '',
+  },
+};

--- a/server/push/push_key.json
+++ b/server/push/push_key.json
@@ -1,7 +1,0 @@
-{
-  "pushServerKey": "",
-  "pushVapidKeys": {
-    "publicKey": "",
-    "privateKey": ""
-  }
-}


### PR DESCRIPTION
 - vapidkeys generate before building client and server
 - vapid public key needed by client and private key must not visible
 - to remove readfile from json, changes to javascript file has json data exported
 - GeneratePushKey function generates vapid keys and write json data as javascript code