### PR TITLE
fix the issue of build_client failure

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -148,7 +148,7 @@ gulp.task('build_client', () => {
           loader: 'babel-loader',
           options: {
             presets: [
-              ['es2015', {modules: false}]
+              ['es2015-without-strict']
             ]
           }
         }]


### PR DESCRIPTION
"build_client" command returns error that couldn't find preset es2015 because
that preset is removed in Introduce access modifier decorator. (#348)
so I made build_client command using the preset es2015-without-strict.